### PR TITLE
Changed the behavior of `rdf_serialize` to accept a vector of prefix to namespace bindings.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,11 @@ Authors@R: c(person("Carl", "Boettiger",
                   comment=c(ORCID = "0000-0002-0381-3766")),
              person("Anna", "Krystalli", 
                   role = "rev",
-                  comment=c(ORCID = "0000-0002-2378-4915")))                  
+                  comment=c(ORCID = "0000-0002-2378-4915")),
+             person("Viktor", "Senderov",
+                  email = "vsenderov@gmail.com",
+                  role = "ctb",
+                  comment = c(ORCID = "0000-0003-3340-5963")))
 Description: The Resource Description Framework, or 'RDF' is a widely used
              data representation model that forms the cornerstone of the 
              Semantic Web. 'RDF' represents data as a graph rather than 

--- a/R/rdf_serialize.R
+++ b/R/rdf_serialize.R
@@ -66,7 +66,7 @@ rdf_serialize <- function(rdf,
     new("Serializer", rdf$world,
         name = format, mimeType = mimetype)
   
-  if(!is.null(namespace) && is.character(namespace) && length(namespace) >= 1){
+  if(!is.null(namespace) && is.character(namespace) && length(namespace) >= 1 && length(namespace) == length(prefix)){
     ix = 1:length(namespace)
     for (i in ix) {
       redland::setNameSpace(serializer,

--- a/R/rdf_serialize.R
+++ b/R/rdf_serialize.R
@@ -4,6 +4,7 @@
 #' @inheritParams rdf_query
 #' @param doc file path to write out to. If null, will write to character.
 #' @param namespace a named character containing the prefix to namespace bindings. \code{names(namespace)} are the prefixes, whereas \code{namespace} are the namespaces
+#' @param prefix (optional) for backward compatibility. See \code{namespace}. It contains the matching prefixes to the namespaces in \code{namespace} and is set automatically if you provide \code{namespace} as a named character vector.
 #' @param ... additional arguments to \code{redland::serializeToFile}
 #' @return rdf_serialize returns the output file path `doc` invisibly.
 #'   This makes it easier to use rdf_serialize in pipe chains with
@@ -19,14 +20,18 @@
 #' out <- tempfile("file", fileext = ".rdf")
 #'
 #' some_rdf <- rdf_parse(infile)
-#' rdf_add(some_rdf, subject = "http://www.dajobe.org/dave-beckett", predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", object = "http://xmlns.com/foaf/0.1/Person")
+#' rdf_add(some_rdf,
+#'     subject = "http://www.dajobe.org/dave-beckett",
+#'     predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+#'     object = "http://xmlns.com/foaf/0.1/Person")
 #' rdf_serialize(some_rdf, out)
 #'
 #' ## With a namespace
 #' rdf_serialize(some_rdf,
 #'           out,
 #'           format = "turtle",
-#'           namespace = c(dc = "http://purl.org/dc/elements/1.1/", foaf = "http://xmlns.com/foaf/0.1/")
+#'           namespace = c(dc = "http://purl.org/dc/elements/1.1/",
+#'           foaf = "http://xmlns.com/foaf/0.1/")
 #'           )
 #'
 #' readLines(out)
@@ -39,6 +44,7 @@ rdf_serialize <- function(rdf,
                                      "turtle",
                                      "jsonld"),
                           namespace = NULL,
+                          prefix = names(namespace),
                           base = getOption("rdf_base_uri", "localhost://"),
                           ...){
   
@@ -66,7 +72,7 @@ rdf_serialize <- function(rdf,
       redland::setNameSpace(serializer,
                             rdf$world,
                             namespace = namespace[i],
-                            prefix = names(namespace)[i]) 
+                            prefix = prefix[i]) 
     }
   }
   

--- a/man/rdf_serialize.Rd
+++ b/man/rdf_serialize.Rd
@@ -6,7 +6,8 @@
 \usage{
 rdf_serialize(rdf, doc = NULL, format = c("guess", "rdfxml", "nquads",
   "ntriples", "turtle", "jsonld"), namespace = NULL,
-  base = getOption("rdf_base_uri", "localhost://"), ...)
+  prefix = names(namespace), base = getOption("rdf_base_uri",
+  "localhost://"), ...)
 }
 \arguments{
 \item{rdf}{an existing rdf triplestore to extend with triples from
@@ -20,6 +21,8 @@ or "jsonld". If not provided, will try to guess based
 on file extension and fall back on rdfxml.}
 
 \item{namespace}{a named character containing the prefix to namespace bindings. \code{names(namespace)} are the prefixes, whereas \code{namespace} are the namespaces}
+
+\item{prefix}{(optional) for backward compatibility. See \code{namespace}. It contains the matching prefixes to the namespaces in \code{namespace} and is set automatically if you provide \code{namespace} as a named character vector.}
 
 \item{base}{the base URI to assume for any relative URIs (blank nodes)}
 
@@ -38,14 +41,18 @@ infile <- system.file("extdata", "dc.rdf", package="redland")
 out <- tempfile("file", fileext = ".rdf")
 
 some_rdf <- rdf_parse(infile)
-rdf_add(some_rdf, subject = "http://www.dajobe.org/dave-beckett", predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", object = "http://xmlns.com/foaf/0.1/Person")
+rdf_add(some_rdf,
+    subject = "http://www.dajobe.org/dave-beckett",
+    predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+    object = "http://xmlns.com/foaf/0.1/Person")
 rdf_serialize(some_rdf, out)
 
 ## With a namespace
 rdf_serialize(some_rdf,
           out,
           format = "turtle",
-          namespace = c(dc = "http://purl.org/dc/elements/1.1/", foaf = "http://xmlns.com/foaf/0.1/")
+          namespace = c(dc = "http://purl.org/dc/elements/1.1/",
+          foaf = "http://xmlns.com/foaf/0.1/")
           )
 
 readLines(out)

--- a/man/rdf_serialize.Rd
+++ b/man/rdf_serialize.Rd
@@ -5,7 +5,7 @@
 \title{Serialize an RDF Document}
 \usage{
 rdf_serialize(rdf, doc = NULL, format = c("guess", "rdfxml", "nquads",
-  "ntriples", "turtle", "jsonld"), namespace = NULL, prefix = NULL,
+  "ntriples", "turtle", "jsonld"), namespace = NULL,
   base = getOption("rdf_base_uri", "localhost://"), ...)
 }
 \arguments{
@@ -19,9 +19,7 @@ one of "rdfxml", "nquads", "ntriples", "turtle"
 or "jsonld". If not provided, will try to guess based
 on file extension and fall back on rdfxml.}
 
-\item{namespace}{string giving the namespace to set}
-
-\item{prefix}{string giving the prefix associated with the namespace}
+\item{namespace}{a named character containing the prefix to namespace bindings. \code{names(namespace)} are the prefixes, whereas \code{namespace} are the namespaces}
 
 \item{base}{the base URI to assume for any relative URIs (blank nodes)}
 
@@ -39,13 +37,16 @@ Serialize an RDF Document
 infile <- system.file("extdata", "dc.rdf", package="redland")
 out <- tempfile("file", fileext = ".rdf")
 
-rdf <- rdf_parse(infile)
-rdf_serialize(rdf, out)
+some_rdf <- rdf_parse(infile)
+rdf_add(some_rdf, subject = "http://www.dajobe.org/dave-beckett", predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", object = "http://xmlns.com/foaf/0.1/Person")
+rdf_serialize(some_rdf, out)
 
 ## With a namespace
-rdf_serialize(rdf,
+rdf_serialize(some_rdf,
           out,
-          namespace = "http://purl.org/dc/elements/1.1/",
-          prefix = "dc")
+          format = "turtle",
+          namespace = c(dc = "http://purl.org/dc/elements/1.1/", foaf = "http://xmlns.com/foaf/0.1/")
+          )
 
+readLines(out)
 }


### PR DESCRIPTION
As sometimes during serialization, one needs to add more than just one prefix to namespace binding, I suggest a change to the `rdf_serialize` function as described below:

Update rdf_serialize.R

Changed the `rdf_serialize` function to accept multiple prefix to namespace mappings via the `namespace` parameter.

The `namespace` parameter needs now to be a named character. `names(namespace)` contains the prefixes, whereas `namespace` itself contains the namespaces. Example:

 ```
 infile <- system.file("extdata", "dc.rdf", package="redland")
 out <- tempfile("file", fileext = ".rdf")
 some_rdf <- rdf_parse(infile)
 rdf_add(some_rdf, subject = "http://www.dajobe.org/dave-beckett", predicate = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", object = "http://xmlns.com/foaf/0.1/Person")
 rdf_serialize(some_rdf, out, format = "turtle", namespace = c(dc = "http://purl.org/dc/elements/1.1/", foaf = "http://xmlns.com/foaf/0.1/") )
 readLines(out)
 ```