### PR TITLE
Fix tests for readr 1.2.0

### DIFF
--- a/tests/testthat/test-rdf_query.R
+++ b/tests/testthat/test-rdf_query.R
@@ -71,8 +71,8 @@ testthat::test_that("SPARQL handles data types", {
   #testthat::expect_type(match$o[[1]], "logical")
   
   match <- rdf_query(rdf, 'SELECT ?o ?s WHERE { ?s <ex:integer> ?o }')
-  testthat::expect_is(match$o[[1]], "integer")
-  testthat::expect_type(match$o[[1]], "integer")
+  testthat::expect_is(match$o[[1]], "numeric")
+  testthat::expect_type(match$o[[1]], "double")
   
   match <- rdf_query(rdf, 'SELECT ?o ?s WHERE { ?s <ex:string> ?o }')
   testthat::expect_is(match$o[[1]], "character")


### PR DESCRIPTION
readr 1.2.0 no longer guesses types of integer, instead it always
guesses a type of numeric (see
https://github.com/tidyverse/readr/blob/master/NEWS.md#integer-column-guessing for details).

This change caused a test to fail, which is fixed here.

I plan to submit readr 1.2.0 to CRAN soon, so you will need to submit rdflib as well with this change to avoid breaking tests on CRAN.

Sorry for the breakage!