### PR TITLE
suppress readr messages from query getResults

### DIFF
--- a/R/rdf_query.R
+++ b/R/rdf_query.R
@@ -59,6 +59,7 @@ getResults <- function(queryResult, format = "csv", ...){
   readr::read_csv(redland::librdf_query_results_to_string2(
                             queryResult@librdf_query_results, 
                             format, mimetype, NULL, NULL), 
+                  progress = FALSE, show_col_types = FALSE,
                   ...)
 }
 


### PR DESCRIPTION
@cboettig This suppresses the annoying verbosity described in #42. It doesn't directly address that issue through enabling `col_types` to be passed to `rdf_query`, but just suppresses the `readr` output. The `readr` options to suppress these are not particularly easy to find, and these outputs are rarely informative here, even in the context of #42, so i'd suggest it's much better to suppress it all here. No worries if you disagree and wanna just close this. Your thoughts @James-G-Hill?