### PR TITLE
suppress readr/vroom warnings

### DIFF
--- a/R/rdf_query.R
+++ b/R/rdf_query.R
@@ -56,9 +56,9 @@ getResults <- function(queryResult, format = "csv", ...){
   mimetype <- switch(format,
                      "csv" = "text/csv; charset=utf-8",
                      NULL)
-  readr::read_csv(redland::librdf_query_results_to_string2(
+  readr::read_csv(I(redland::librdf_query_results_to_string2(
                             queryResult@librdf_query_results, 
-                            format, mimetype, NULL, NULL), 
+                            format, mimetype, NULL, NULL)),
                   progress = FALSE, show_col_types = FALSE,
                   ...)
 }


### PR DESCRIPTION
@cboettig Another dependency update that requires changes here. `readr::read_csv` now passes directly to `vroom` which does this:
https://github.com/tidyverse/vroom/blob/2218ba0e311e200e359469542e049ab6f34a5683/R/path.R#L49

That `soft_deprecate` is issued as a warning, and thus packages depending on `rdflib` fail R CMD checks. Here's an [equivalent fix from rOpenSci's {nasapower} pkg](https://github.com/ropensci/nasapower/pull/67) courtesy of @palderman. I haven't thought about the consequences of this change, or whether there might be edge cases not compatible with passing literal args via `I()`, so maybe think about that at least briefly before merging this? Thanks!